### PR TITLE
Add interactive learning app

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,35 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+nav {
+  background: #333;
+  color: #fff;
+  padding: 10px;
+  display: flex;
+  gap: 10px;
+}
+nav button {
+  background: #555;
+  border: none;
+  color: white;
+  padding: 10px;
+  cursor: pointer;
+}
+nav button:hover {
+  background: #777;
+}
+.panel {
+  padding: 20px;
+}
+.hidden {
+  display: none;
+}
+#flashcard-answer {
+  margin-top: 10px;
+  font-weight: bold;
+}
+progress {
+  width: 100%;
+}

--- a/data/lernkarten.json
+++ b/data/lernkarten.json
@@ -1,0 +1,27 @@
+[
+  {
+    "frage": "Was versteht man unter Liquidität 1. Grades?",
+    "antwort": "Flüssige Mittel / kurzfristige Verbindlichkeiten * 100",
+    "kategorie": "BWL-Grundlagen"
+  },
+  {
+    "frage": "Nenne ein Beispiel für eine Praxisgründungsform",
+    "antwort": "Einzelpraxis, Gemeinschaftspraxis oder Praxisgemeinschaft",
+    "kategorie": "Praxisgründung"
+  },
+  {
+    "frage": "Welche Kostenart stellt die Miete dar?",
+    "antwort": "Fixkosten",
+    "kategorie": "Kostenrechnung"
+  },
+  {
+    "frage": "Wie heißt das Gesetz, das die Berufsrechte von Psychologen regelt?",
+    "antwort": "Psychotherapeutengesetz (PsychThG)",
+    "kategorie": "Berufsrecht"
+  },
+  {
+    "frage": "Was beschreibt die Gesundheitsökonomie?",
+    "antwort": "Sie untersucht die Ressourcenverteilung und Effizienz im Gesundheitswesen",
+    "kategorie": "Gesundheitsökonomie"
+  }
+]

--- a/data/quizfragen.json
+++ b/data/quizfragen.json
@@ -1,0 +1,19 @@
+[
+  {
+    "frage": "Welcher Bestandteil gehört nicht zur Bilanz?",
+    "typen": "mc",
+    "antworten": ["Aktiva", "Passiva", "GuV", "Eigenkapital"],
+    "loesung": 2
+  },
+  {
+    "frage": "Was ist ein Vorteil einer Gemeinschaftspraxis?",
+    "typen": "mc",
+    "antworten": ["Höhere Miete", "Geteilte Kosten", "Weniger Patienten", "Mehr Bürokratie"],
+    "loesung": 1
+  },
+  {
+    "frage": "Erklären Sie das Kostendeckungsprinzip.",
+    "typen": "offen",
+    "loesung": "Einnahmen decken die entstandenen Kosten vollständig ab"
+  }
+]

--- a/data/rechenaufgaben.json
+++ b/data/rechenaufgaben.json
@@ -1,0 +1,10 @@
+[
+  {
+    "frage": "Berechne die Liquidität 1. Grades bei 50.000 € flüssigen Mitteln und 80.000 € kurzfristigen Verbindlichkeiten.",
+    "loesung": 62.5
+  },
+  {
+    "frage": "Berechne die Umsatzrentabilität bei 20.000 € Gewinn und 150.000 € Umsatz (in %).",
+    "loesung": 13.33
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lern-App Klinische Psychologie</title>
+<link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<h1>Lern-App Klinische Psychologie - Management für Psychologen</h1>
+<nav id="menu">
+<button data-target="flashcards">Lernkarten</button>
+<button data-target="quiz">Quiz</button>
+<button data-target="math">Rechenaufgaben</button>
+<button data-target="editor">Editor</button>
+<button data-target="progress">Fortschritt</button>
+</nav>
+<div id="flashcards" class="panel hidden">
+<h2>Lernkarten</h2>
+<div id="flashcard-question"></div>
+<button id="show-answer">Antwort anzeigen</button>
+<div id="flashcard-answer" class="hidden"></div>
+<button id="knew">Ich wusste es</button>
+<button id="didnt-know">Ich wusste es nicht</button>
+<div id="flashcard-progress"></div>
+<label><input type="checkbox" id="shuffle"> Zufällige Reihenfolge</label>
+<select id="category-filter"></select>
+</div>
+<div id="quiz" class="panel hidden">
+<h2>Quiz</h2>
+<div id="quiz-container"></div>
+<div id="quiz-score"></div>
+</div>
+<div id="math" class="panel hidden">
+<h2>Rechenaufgaben</h2>
+<div id="math-container"></div>
+</div>
+<div id="editor" class="panel hidden">
+<h2>Editor</h2>
+<form id="editor-form">
+<label>Frage:<br><textarea id="editor-question" required></textarea></label><br>
+<label>Antwort:<br><textarea id="editor-answer" required></textarea></label><br>
+<label>Kategorie:<br><input type="text" id="editor-category"></label><br>
+<button type="submit">Speichern</button>
+</form>
+</div>
+<div id="progress" class="panel hidden">
+<h2>Fortschritt</h2>
+<div id="progress-stats"></div>
+<canvas id="progress-chart" width="400" height="200"></canvas>
+</div>
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,184 @@
+let flashcards = [];
+let quizQuestions = [];
+let mathTasks = [];
+let flashcardIndex = 0;
+let knewCount = 0;
+let didntKnowCount = 0;
+
+async function loadData() {
+  flashcards = await fetch('data/lernkarten.json').then(r => r.json());
+  quizQuestions = await fetch('data/quizfragen.json').then(r => r.json());
+  mathTasks = await fetch('data/rechenaufgaben.json').then(r => r.json());
+  const custom = JSON.parse(localStorage.getItem('customCards') || '[]');
+  originalFlashcards = flashcards.concat(custom);
+  flashcards = originalFlashcards;
+  initFlashcards();
+  initQuiz();
+  initMath();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadData();
+  setupMenu();
+  document.getElementById('editor-form').addEventListener('submit', saveFlashcard);
+});
+
+function setupMenu() {
+  document.querySelectorAll('#menu button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('.panel').forEach(p => p.classList.add('hidden'));
+      document.getElementById(btn.dataset.target).classList.remove('hidden');
+    });
+  });
+}
+
+// Flashcards
+function initFlashcards() {
+  const categorySelect = document.getElementById('category-filter');
+  const categories = [...new Set(flashcards.map(f => f.kategorie))];
+  categorySelect.innerHTML = '<option value="alle">Alle Kategorien</option>' +
+    categories.map(c => `<option value="${c}">${c}</option>`).join('');
+  document.getElementById('show-answer').addEventListener('click', () => {
+    document.getElementById('flashcard-answer').classList.remove('hidden');
+  });
+  document.getElementById('knew').addEventListener('click', () => {
+    knewCount++; nextFlashcard();
+  });
+  document.getElementById('didnt-know').addEventListener('click', () => {
+    didntKnowCount++; nextFlashcard();
+  });
+  document.getElementById('shuffle').addEventListener('change', startFlashcards);
+  categorySelect.addEventListener('change', startFlashcards);
+  startFlashcards();
+}
+
+function startFlashcards() {
+  flashcardIndex = 0;
+  let cards = filterFlashcards();
+  if (document.getElementById('shuffle').checked) {
+    cards = cards.sort(() => Math.random() - 0.5);
+  }
+  flashcards = cards;
+  knewCount = didntKnowCount = 0;
+  showFlashcard();
+  updateProgress();
+}
+
+function filterFlashcards() {
+  const cat = document.getElementById('category-filter').value;
+  if (cat === 'alle') return originalFlashcards;
+  return originalFlashcards.filter(f => f.kategorie === cat);
+}
+
+function showFlashcard() {
+  if (flashcardIndex >= flashcards.length) {
+    document.getElementById('flashcard-question').textContent = 'Fertig!';
+    document.getElementById('flashcard-answer').textContent = '';
+    return;
+  }
+  const card = flashcards[flashcardIndex];
+  document.getElementById('flashcard-question').textContent = card.frage;
+  document.getElementById('flashcard-answer').textContent = card.antwort;
+  document.getElementById('flashcard-answer').classList.add('hidden');
+  updateProgress();
+}
+
+function nextFlashcard() {
+  flashcardIndex++;
+  showFlashcard();
+}
+
+function updateProgress() {
+  const progress = ((flashcardIndex) / flashcards.length) * 100;
+  document.getElementById('flashcard-progress').textContent = `Fortschritt: ${flashcardIndex} / ${flashcards.length}`;
+}
+
+let originalFlashcards = [];
+
+// Quiz
+function initQuiz() {
+  const container = document.getElementById('quiz-container');
+  quizQuestions.forEach((q, idx) => {
+    const div = document.createElement('div');
+    div.className = 'quiz-question';
+    const h3 = document.createElement('h3');
+    h3.textContent = q.frage;
+    div.appendChild(h3);
+    if (q.typen === 'mc') {
+      q.antworten.forEach((a, i) => {
+        const label = document.createElement('label');
+        const input = document.createElement('input');
+        input.type = 'radio';
+        input.name = 'q' + idx;
+        input.value = i;
+        label.appendChild(input);
+        label.append(' ' + a);
+        div.appendChild(label);
+        div.appendChild(document.createElement('br'));
+      });
+      const btn = document.createElement('button');
+      btn.textContent = 'Antwort prüfen';
+      btn.addEventListener('click', () => {
+        const selected = div.querySelector('input:checked');
+        if (!selected) return;
+        const correct = parseInt(selected.value) === q.loesung;
+        if (correct) btn.textContent = 'Richtig!';
+        else btn.textContent = 'Falsch!';
+      });
+      div.appendChild(btn);
+    } else {
+      const btn = document.createElement('button');
+      btn.textContent = 'Lösung anzeigen';
+      const ans = document.createElement('div');
+      ans.className = 'hidden';
+      ans.textContent = q.loesung;
+      btn.addEventListener('click', () => ans.classList.toggle('hidden'));
+      div.appendChild(btn);
+      div.appendChild(ans);
+    }
+    container.appendChild(div);
+  });
+}
+
+// Math tasks
+function initMath() {
+  const container = document.getElementById('math-container');
+  mathTasks.forEach((t, idx) => {
+    const div = document.createElement('div');
+    div.className = 'math-task';
+    const q = document.createElement('div');
+    q.textContent = t.frage;
+    const input = document.createElement('input');
+    input.type = 'number';
+    const btn = document.createElement('button');
+    btn.textContent = 'Berechnen';
+    const feedback = document.createElement('span');
+    btn.addEventListener('click', () => {
+      const value = parseFloat(input.value);
+      if (Math.abs(value - t.loesung) < 0.01) {
+        feedback.textContent = 'Richtig!';
+      } else {
+        feedback.textContent = `Falsch! Lösung: ${t.loesung}`;
+      }
+    });
+    div.appendChild(q);
+    div.appendChild(input);
+    div.appendChild(btn);
+    div.appendChild(feedback);
+    container.appendChild(div);
+  });
+}
+
+function saveFlashcard(e) {
+  e.preventDefault();
+  const card = {
+    frage: document.getElementById('editor-question').value,
+    antwort: document.getElementById('editor-answer').value,
+    kategorie: document.getElementById('editor-category').value || 'Allgemein'
+  };
+  const stored = JSON.parse(localStorage.getItem('customCards') || '[]');
+  stored.push(card);
+  localStorage.setItem('customCards', JSON.stringify(stored));
+  alert('Gespeichert!');
+  e.target.reset();
+}


### PR DESCRIPTION
## Summary
- add HTML layout with panels for flashcards, quiz, math tasks, editor and progress
- include basic styling
- implement vanilla JS logic for loading data, flashcards, quiz and math evaluation
- provide sample JSON datasets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68607fff33948320b61df0e883227754